### PR TITLE
Update Dockerfile for perl-tidy 20200110

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM opensuse/tumbleweed
-LABEL maintainer Sergio Lindo Mansilla <slindomansilla@suse.com>
+LABEL maintainer Sergio Lindo Mansilla <sergiolindo.empresa@gmail.com>
 
-RUN groupadd -r nogroup
-RUN useradd -r -g nogroup nobody
 RUN zypper --gpg-auto-import-keys ref
 RUN zypper --non-interactive dup
+RUN zypper --non-interactive in --force-resolution shadow
 RUN zypper --non-interactive in --force-resolution which
-RUN zypper --non-interactive in --force-resolution perl-Perl-Tidy-20190601
+RUN zypper --non-interactive in --force-resolution perl-Perl-Tidy-20200110
+RUN groupadd -r nogroup
+RUN useradd -r -g nogroup nobody
 
 COPY tool/.perltidyrc /etc/os-autoinst/
 COPY tool/tidy.sh /usr/local/bin/
@@ -14,3 +15,4 @@ COPY tool/tidy.sh /usr/local/bin/
 USER nobody:nogroup
 WORKDIR /tmp/mess
 ENTRYPOINT [ "tidy.sh" ]
+


### PR DESCRIPTION
- Containers doesn't deliver groupadd command
  Package shadow needs to be installed
- Current version of perl-tidy in travis and Tumbleweed is 20200110