### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Find it here: https://hub.docker.com/r/binarysequence/os-autoinst-perl-tidy/
 
 ```bash
 # Pull image
-docker pull binarysequence/os-autoinst-perl-tidy:2018-03-05_2018-02-20
+docker pull binarysequence/os-autoinst-perl-tidy:latest
 
 # Run container to check (files won't be changed)
-docker container run -v /Users/sergio/github/os-autoinst-distri-opensuse/:/tmp/mess binarysequence/os-autoinst-perl-tidy:2018-03-05_2018-02-20
+docker container run -v /Users/sergio/github/os-autoinst-distri-opensuse/:/tmp/mess binarysequence/os-autoinst-perl-tidy:latest
 
 # Run container to edit files in place
-docker container run -v /Users/sergio/github/os-autoinst-distri-opensuse/:/tmp/mess binarysequence/os-autoinst-perl-tidy:2018-03-05_2018-02-20 --replace
+docker container run -v /Users/sergio/github/os-autoinst-distri-opensuse/:/tmp/mess binarysequence/os-autoinst-perl-tidy:latest --replace
 
 # The volume is the project that you want to tidy (os-autoinst, os-autoinst-distri-opensuse, etc)
 ```
@@ -37,7 +37,7 @@ id
 
 # I assume that the directory has write permissions for your user, if not, the following will not work
 # --user 1000
-docker container run --user 1000 -v /home/mansilla/github/os-autoinst-distri-opensuse/:/tmp/mess binarysequence/os-autoinst-perl-tidy:2018-03-05_2018-02-20 --replace
+docker container run --user 1000 -v /home/mansilla/github/os-autoinst-distri-opensuse/:/tmp/mess binarysequence/os-autoinst-perl-tidy:latest --replace
 ```
 
 In my case, I have my github code directy in used by a local openQA instance and have the user geekotest as owner. So in my case I have to find the uid of geekotest and give the container the privileges as geekotest.
@@ -46,5 +46,5 @@ In my case, I have my github code directy in used by a local openQA instance and
 # Find uid
 id geekotest
 # Output example: uid=489(geekotest) gid=65534(nogroup) groups=1000(developers),65534(nogroup)
-docker container run --user 489 -v /home/mansilla/github/os-autoinst-distri-opensuse/:/tmp/mess binarysequence/os-autoinst-perl-tidy:2018-03-05_2018-02-20 --replace
+docker container run --user 489 -v /home/mansilla/github/os-autoinst-distri-opensuse/:/tmp/mess binarysequence/os-autoinst-perl-tidy:latest --replace
 ```


### PR DESCRIPTION
Point to docker image tag latest. This avoid to update the README file
each tile a new image is pushed.